### PR TITLE
use libsodium from ports on OpenBSD

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,6 +32,14 @@
         '<!(node preinstall.js --print-lib)'
       ],
       'conditions': [
+        ['OS=="openbsd"', {
+          'libraries': [
+            '-lsodium',
+          ],
+          'include_dirs': [
+            '<!(pkg-config --cflags libsodium | cut -dI -f2)',
+          ]
+        }],
         ['OS=="linux"', {
           'link_settings': {
             'libraries': [ "-Wl,-rpath=\\$$ORIGIN/"]

--- a/postinstall.js
+++ b/postinstall.js
@@ -17,6 +17,9 @@ switch (os.platform()) {
     buildDarwin()
     break
 
+  case 'openbsd':
+    break
+
   default:
     buildLinux()
     break

--- a/preinstall.js
+++ b/preinstall.js
@@ -28,6 +28,8 @@ if (process.argv.indexOf('--print-lib') > -1) {
     case 'linux':
       console.log(path.join(__dirname, '/deps/lib/libsodium.so.18'))
       break
+    case 'openbsd':
+      break
     case 'win32':
       console.log('../deps/libsodium/Build/ReleaseDLL/' + warch + '/libsodium.lib')
       break
@@ -49,6 +51,9 @@ switch (os.platform()) {
 
   case 'win32':
     buildWindows()
+    break
+
+  case 'openbsd':
     break
 
   default:


### PR DESCRIPTION
@emilbayes I am not sure if using an external libsodium is expectable here.

 I can change it to use the vendor'd libsodium - on OpenBSD we put a lot of effort into maintaining the ports tree, so we try to keep the duplicated dependencies minimal where we can (makes security updates much less painful). 