### PR TITLE
tracking: add functions for converting ed25519 to curve25519

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -147,6 +147,19 @@ NAN_METHOD(crypto_sign_detached) {
   CALL_SODIUM(crypto_sign_detached(CDATA(signature), &signature_length_dummy, CDATA(message), CLENGTH(message), CDATA(secret_key)))
 }
 
+NAN_METHOD(crypto_sign_ed25516_pk_to_curve25519) {
+  ASSERT_BUFFER_MIN_LENGTH(info[0], curve25519_pk, crypto_box_PUBLICKEYBYTES)
+  ASSERT_BUFFER_MIN_LENGTH(info[1], ed25519_pk, crypto_sign_PUBLICKEYBYTES)
+  CALL_SODIUM(crypto_sign_ed25519_pk_to_curve25519(CDATA(curve25519_pk), CDATA(ed25519_pk)))
+}
+
+NAN_METHOD(crypto_sign_ed25516_sk_to_curve25519) {
+  ASSERT_BUFFER_MIN_LENGTH(info[0], curve25519_sk, crypto_box_SECRETKEYBYTES)
+  ASSERT_BUFFER_MIN_LENGTH(info[1], ed25519_sk, crypto_sign_SECRETKEYBYTES)
+  CALL_SODIUM(crypto_sign_ed25519_sk_to_curve25519(CDATA(curve25519_sk), CDATA(ed25519_sk)))
+}
+
+
 NAN_METHOD(crypto_sign_verify_detached) {
   ASSERT_BUFFER_MIN_LENGTH(info[0], signature, crypto_sign_BYTES)
   ASSERT_BUFFER(info[1], message)
@@ -633,6 +646,8 @@ NAN_MODULE_INIT(InitAll) {
   EXPORT_FUNCTION(crypto_sign_open)
   EXPORT_FUNCTION(crypto_sign_detached)
   EXPORT_FUNCTION(crypto_sign_verify_detached)
+  EXPORT_FUNCTION(crypto_sign_ed25519_pk_to_curve25519)
+  EXPORT_FUNCTION(crypto_sign_ed25519_sk_to_curve25519)
 
   // crypto_generic_hash
 
@@ -825,3 +840,8 @@ NODE_MODULE(sodium, InitAll)
 #undef ASSERT_UINT
 #undef CALL_SODIUM
 #undef CALL_SODIUM_BOOL
+
+
+
+
+


### PR DESCRIPTION
This adds `crypto_sign_ed25519_pk_to_curve25519` and `crypto_sign_ed25519_sk_to_curve25519`.
These are both methods needed by ssb, and https://github.com/dominictarr/sodium-chloride

Making this PR for tracking purposes, will need to make PRs for the tests and to sodium-javascript too.