### PR TITLE
adds the tests and docs for conversion functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ Verify a signature.
 
 Will return `true` if the message could be verified. Otherwise `false`.
 
+####`crypto_sign_ed25519_pk_to_curve25519(curve_pk, ed_pk)
+
+convert a ed25519 public key to curve25519 (which can be used with `box` and `scalarmult`)
+* `curve_pk` should be a buffer with length `crypto_box_PUBLICKEYBYTES`
+* `ed_pk` should be a buffer with length `crypto_sign_PUBLICKEYBYTES`
+
+####`crypto_sign_ed25519_sk_to_curve25519(curve_sk, ed_sk)
+
+convert a ed25519 secret key to curve25519 (which can be used with `box` and `scalarmult`)
+* `curve_sk` should be a buffer with length `crypto_box_SECRETKEYBYTES`
+* `ed_sk` should be a buffer with length `crypto_sign_SECRETKEYBYTES`
+
 ### Generic hashing
 
 Bindings for the crypto_generichash API.
@@ -664,3 +676,4 @@ The generated hash is stored in `output`.
 ## License
 
 MIT
+

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node-gyp": "^3.6.1",
     "prebuildify": "^2.1.0",
     "sodium-test": "^0.1.0",
+    "sodium-vectors": "^1.0.0",
     "standard": "^8.6.0",
     "tape": "^4.6.3"
   },

--- a/test/vectors.js
+++ b/test/vectors.js
@@ -1,0 +1,2 @@
+
+require('sodium-vectors')(require('../'))


### PR DESCRIPTION
I generated deterministic test vectors,
https://github.com/dominictarr/sodium-vectors
and these are used in the tests.
this makes it easy to compare different versions, or run the tests in a browser.
the vectors are fully deterministic, and since everything is in base64 and json means it would be easy to use these vectors in an implementation in another language too.

the basic idea, is to call each method, and snapshot the return value, and the args before and after calling the method. (which works with how sodium mutates it's args)

Also, I make a point of testing invalid inputs - flipping a bit in a signature should make it an invalid signature, this is repeated for anything that ought to break with a single flipped bit.

should I transfer sodium-vectors to sodium-friends?