### PR TITLE
prebuild for arm

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "install": "node-gyp-build \"node preinstall.js\" \"node postinstall.js\"",
     "prebuild": "prebuildify -a --strip --preinstall \"node preinstall.js\" --postinstall \"node postinstall.js\"",
     "prebuild-ia32": "prebuildify -a --strip --preinstall \"node preinstall.js\" --postinstall \"node postinstall.js\" --arch=ia32"
+    "prebuild-arm": "prebuildify -a --strip --preinstall \"node preinstall.js\" --postinstall \"node postinstall.js\" --arch=arm"
   },
   "repository": {
     "type": "git",
@@ -35,3 +36,4 @@
   },
   "homepage": "https://github.com/sodium-friends/sodium-native"
 }
+


### PR DESCRIPTION
I'm trying to get sodium-native working on linux-arm.
I did this, and it built on my laptop fine,
but on my arm device (rooted nexus 5 with arch linux running inside container)
it gave this error:

```
Error: /home/android/sodium-native/prebuilds/linux-arm/node-51.node: wrong ELF class: ELFCLASS64
    at Object.Module._extensions..node (module.js:598:18)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at load (/home/android/sodium-native/node_modules/node-gyp-build/index.js:13:10)
    at Object.<anonymous> (/home/android/sodium-native/index.js:1:101)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
```

and when trying to build directly on the phone, it gave this python error:

```
...
make[2]: Leaving directory '/home/android/sodium-native/deps/libsodium'
make[1]: Leaving directory '/home/android/sodium-native/deps/libsodium'
Traceback (most recent call last):
  File "/home/android/.nvm/versions/node/v7.10.0/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py", line 13, in <module>
    import gyp
  File "/home/android/.nvm/versions/node/v7.10.0/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 8, in <module>
    import gyp.input
  File "/home/android/.nvm/versions/node/v7.10.0/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 13, in <module>
    import gyp.common
  File "/home/android/.nvm/versions/node/v7.10.0/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/common.py", line 12, in <module>
    import tempfile
  File "/usr/lib/python2.7/tempfile.py", line 35, in <module>
    from random import Random as _Random
  File "/usr/lib/python2.7/random.py", line 885, in <module>
    _inst = Random()
  File "/usr/lib/python2.7/random.py", line 97, in __init__
    self.seed(x)
  File "/usr/lib/python2.7/random.py", line 113, in seed
    a = long(_hexlify(_urandom(2500)), 16)
OSError: [Errno 38] Function not implemented
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/home/android/.nvm/versions/node/v7.10.0/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:308:16)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:194:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexi
```

although, otherwise, the build looked good