### PR TITLE
fix build on openbsd

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -46,7 +46,18 @@ function buildLinux () {
 }
 
 function buildBSD () {
-  buildLinux()
+  var lib = path.join(__dirname, 'lib/libsodium-' + arch + '.so.23')
+  var dst = path.join(build, 'libsodium.so.23')
+
+  if (os.platform() === 'openbsd') {
+    lib = lib + '.0'
+    dst = dst + '.0'
+  }
+
+  if (fs.existsSync(dst)) return
+  copy(lib, dst, function (err) {
+    if (err) throw err
+  })
 }
 
 function buildDarwin () {

--- a/preinstall.js
+++ b/preinstall.js
@@ -25,8 +25,10 @@ if (process.argv.indexOf('--print-lib') > -1) {
     case 'darwin':
       console.log('../lib/libsodium-' + arch + '.dylib')
       break
-    case 'freebsd':
     case 'openbsd':
+      console.log(path.join(__dirname, 'lib/libsodium-' + arch + '.so.23.0'))
+      break
+    case 'freebsd':
     case 'linux':
       console.log(path.join(__dirname, 'lib/libsodium-' + arch + '.so.23'))
       break
@@ -51,8 +53,12 @@ switch (os.platform()) {
     buildWindows()
     break
 
-  case 'freebsd':
   case 'openbsd':
+    buildUnix('so.23.0', function (err) {
+      if (err) throw err
+    })
+    break
+  case 'freebsd':
     buildBSD()
     break
 


### PR DESCRIPTION
Libsodium on OpenBSD builds with a .so.XX.Y  extension. This re-introduces that.