### PR TITLE
bindings: Correct confusing typo in buffer checks

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -392,10 +392,10 @@ NAN_METHOD(crypto_sign_seed_keypair) {
     crypto_sign_PUBLICKEYBYTES,
     crypto_sign_publickeybytes())
   ASSERT_BUFFER_MIN_LENGTH(info[1], secret_key,
-    crypto_sign_PUBLICKEYBYTES,
+    crypto_sign_SECRETKEYBYTES,
     crypto_sign_secretkeybytes())
   ASSERT_BUFFER_MIN_LENGTH(info[2], seed,
-    crypto_sign_PUBLICKEYBYTES,
+    crypto_sign_SEEDBYTES,
     crypto_sign_seedbytes())
 
   CALL_SODIUM(crypto_sign_seed_keypair(CDATA(public_key), CDATA(secret_key), CDATA(seed)))
@@ -406,7 +406,7 @@ NAN_METHOD(crypto_sign_keypair) {
     crypto_sign_PUBLICKEYBYTES,
     crypto_sign_publickeybytes())
   ASSERT_BUFFER_MIN_LENGTH(info[1], secret_key,
-    crypto_sign_PUBLICKEYBYTES,
+    crypto_sign_SECRETKEYBYTES,
     crypto_sign_secretkeybytes())
 
   CALL_SODIUM(crypto_sign_keypair(CDATA(public_key), CDATA(secret_key)))
@@ -418,7 +418,7 @@ NAN_METHOD(crypto_sign) {
     `message.length + crypto_sign_BYTES`,
     message_length + crypto_sign_bytes())
   ASSERT_BUFFER_MIN_LENGTH(info[2], secret_key,
-    crypto_sign_PUBLICKEYBYTES,
+    crypto_sign_SECRETKEYBYTES,
     crypto_sign_secretkeybytes())
 
   unsigned long long signed_message_length_dummy;  // TODO: what is this used for?


### PR DESCRIPTION
The error message in the following (incorrect) call was confusing:

    const sodium = require('sodium-native'); void 0;
    const public_key = Buffer.alloc( sodium.crypto_sign_PUBLICKEYBYTES );
    const secret_key = Buffer.alloc( sodium.crypto_sign_PUBLICKEYBYTES );
    const seed = crypto.randomBytes( sodium.crypto_sign_PUBLICKEYBYTES );
    sodium.crypto_sign_seed_keypair( public_key, secret_key, seed );

    Error: secret_key must be a buffer of size crypto_sign_PUBLICKEYBYTES

This commit fixes the error message to indicate the correct named
length. The above is the only example of really misleading output:
crypto_sign_SECRETKEYBYTES is 64, but crypto_sign_PUBLICKEYBYTES is 32.

A few other similar typos are fixed, but crypto_sign_SEEDBYTES is also 32,
so other than being inconsistent, it was not too confusing.