### PR TITLE
Add Android support to preinstall.js

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -26,6 +26,7 @@ if (process.argv.indexOf('--print-lib') > -1) {
     case 'darwin':
       console.log('../lib/libsodium-' + arch + '.dylib')
       break
+    case 'android':
     case 'openbsd':
     case 'freebsd':
     case 'linux':
@@ -35,7 +36,7 @@ if (process.argv.indexOf('--print-lib') > -1) {
       console.log('../libsodium/Build/ReleaseDLL/' + warch + '/libsodium.lib')
       break
     default:
-      process.exit(1)
+      throw new Error('Unsupported platform: ' + os.platform())
   }
 
   process.exit(0)


### PR DESCRIPTION
Problem: When compiling from source on Android, the process exits with
code 1 without printing an error.

Solution: Add console output in case of an error, which may be useful
for debugging, and treat the Android platform the same way that we're
currently treating OpenBSD, FreeBSD, and Linux.

---

See also: https://github.com/sodium-friends/sodium-native/issues/119#issuecomment-590003696