### PR TITLE
Fix binding typo error message[)

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -364,7 +364,7 @@ napi_value sn_crypto_sign_verify_detached(napi_env env, napi_callback_info info)
   SN_ARGV_TYPEDARRAY(m, 1)
   SN_ARGV_TYPEDARRAY(pk, 2)
 
-  SN_ASSERT_MIN_LENGTH(sig_size, crypto_sign_BYTES, "m")
+  SN_ASSERT_MIN_LENGTH(sig_size, crypto_sign_BYTES, "sig")
   SN_ASSERT_LENGTH(pk_size, crypto_sign_PUBLICKEYBYTES, "pk")
 
   SN_RETURN_BOOLEAN(crypto_sign_verify_detached(sig_data, m_data, m_size, pk_data))


### PR DESCRIPTION
Problem: When the signature size is invalid, the error message reports
that "m" has an incorrect size. It should be "sig".

Solution: Replace "m" with "sig" in `binding.c` to resolve the typo.

Fixes: https://github.com/sodium-friends/sodium-native/issues/129