### PR TITLE
Remove stdlib dependency

### DIFF
--- a/modules/crypto_tweak/tweak.c
+++ b/modules/crypto_tweak/tweak.c
@@ -68,7 +68,7 @@ void crypto_tweak_ed25519(unsigned char *n, unsigned char *q,
     crypto_scalarmult_ed25519_base_noclamp(q, n64);
   }
 
-  SN_COPY_32(n, n64)
+  SN_TWEAK_COPY_32(n, n64)
 }
 
 int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *siglen_p,
@@ -110,7 +110,7 @@ int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *s
   crypto_core_ed25519_scalar_mul(sig, hram, sk);
   crypto_core_ed25519_scalar_add(sig + 32, nonce, sig);
 
-  SN_COPY_32(sig, R)
+  SN_TWEAK_COPY_32(sig, R)
 
   if (siglen_p != NULL) {
     *siglen_p = 64U;
@@ -130,7 +130,7 @@ void crypto_tweak_ed25519_sk_to_scalar(unsigned char *n, const unsigned char *sk
   n64[31] &= 127;
   n64[31] |= 64;
 
-  SN_COPY_32(n, n64)
+  SN_TWEAK_COPY_32(n, n64)
 }
 
 // tweak a secret key

--- a/modules/crypto_tweak/tweak.c
+++ b/modules/crypto_tweak/tweak.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include "tweak.h"
 
 /*
@@ -69,7 +68,7 @@ void crypto_tweak_ed25519(unsigned char *n, unsigned char *q,
     crypto_scalarmult_ed25519_base_noclamp(q, n64);
   }
 
-  memcpy(n, n64, 32);
+  for (int i = 0; i < 32; i++) n[i] = n64[i];
 }
 
 int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *siglen_p,
@@ -133,7 +132,7 @@ void crypto_tweak_ed25519_sk_to_scalar(unsigned char *n, const unsigned char *sk
   n64[31] &= 127;
   n64[31] |= 64;
 
-  memcpy(n, n64, 32);
+  for (int i = 0; i < 32; i++) n[i] = n64[i];
 }
 
 // tweak a secret key

--- a/modules/crypto_tweak/tweak.c
+++ b/modules/crypto_tweak/tweak.c
@@ -68,7 +68,7 @@ void crypto_tweak_ed25519(unsigned char *n, unsigned char *q,
     crypto_scalarmult_ed25519_base_noclamp(q, n64);
   }
 
-  for (int i = 0; i < 32; i++) n[i] = n64[i];
+  COPY_32(n, n64)
 }
 
 int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *siglen_p,
@@ -110,9 +110,7 @@ int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *s
   crypto_core_ed25519_scalar_mul(sig, hram, sk);
   crypto_core_ed25519_scalar_add(sig + 32, nonce, sig);
 
-  // set nonce and sig
-  for (int i = 0U; i < 32; i++) sig[i] = R[i];
-  // memcpy(sig, R, 32);
+  COPY_32(sig, R)
 
   if (siglen_p != NULL) {
     *siglen_p = 64U;

--- a/modules/crypto_tweak/tweak.c
+++ b/modules/crypto_tweak/tweak.c
@@ -68,7 +68,7 @@ void crypto_tweak_ed25519(unsigned char *n, unsigned char *q,
     crypto_scalarmult_ed25519_base_noclamp(q, n64);
   }
 
-  COPY_32(n, n64)
+  SN_COPY_32(n, n64)
 }
 
 int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *siglen_p,
@@ -110,7 +110,7 @@ int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *s
   crypto_core_ed25519_scalar_mul(sig, hram, sk);
   crypto_core_ed25519_scalar_add(sig + 32, nonce, sig);
 
-  COPY_32(sig, R)
+  SN_COPY_32(sig, R)
 
   if (siglen_p != NULL) {
     *siglen_p = 64U;

--- a/modules/crypto_tweak/tweak.c
+++ b/modules/crypto_tweak/tweak.c
@@ -130,7 +130,7 @@ void crypto_tweak_ed25519_sk_to_scalar(unsigned char *n, const unsigned char *sk
   n64[31] &= 127;
   n64[31] |= 64;
 
-  for (int i = 0; i < 32; i++) n[i] = n64[i];
+  SN_COPY_32(n, n64)
 }
 
 // tweak a secret key

--- a/modules/crypto_tweak/tweak.h
+++ b/modules/crypto_tweak/tweak.h
@@ -1,5 +1,16 @@
 #include <sodium.h>
 
+// copy 32 bytes using int64_t pointers
+#define COPY_32(a, b) \
+  { \
+    long long *dst = (long long *) a; \
+    long long *src = (long long *) b; \
+    dst[0] = src[0]; \
+    dst[1] = src[1]; \
+    dst[2] = src[2]; \
+    dst[3] = src[3]; \
+  }
+
 #define crypto_tweak_ed25519_BYTES crypto_sign_ed25519_PUBLICKEYBYTES
 
 #define crypto_tweak_ed25519_SCALARBYTES crypto_scalarmult_ed25519_SCALARBYTES

--- a/modules/crypto_tweak/tweak.h
+++ b/modules/crypto_tweak/tweak.h
@@ -1,7 +1,7 @@
 #include <sodium.h>
 
 // copy 32 bytes using int64_t pointers
-#define COPY_32(a, b) \
+#define SN_COPY_32(a, b) \
   { \
     long long *dst = (long long *) a; \
     long long *src = (long long *) b; \

--- a/modules/crypto_tweak/tweak.h
+++ b/modules/crypto_tweak/tweak.h
@@ -1,7 +1,7 @@
 #include <sodium.h>
 
 // copy 32 bytes using int64_t pointers
-#define SN_COPY_32(a, b) \
+#define SN_TWEAK_COPY_32(a, b) \
   { \
     long long *dst = (long long *) a; \
     long long *src = (long long *) b; \


### PR DESCRIPTION
This PR removes the `string.h` dependency.

Previously `memcpy` was used to write from intermediate values to the returned value. In both cases only 32 bytes were copied, so a naive for loop is used instead.