### PR TITLE
Standardise `crypto_tweak` api

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -2829,8 +2829,8 @@ napi_value sn_crypto_stream_salsa20_xor_wrap_final (napi_env env, napi_callback_
 
 // Experimental API
 
-napi_value sn_crypto_tweak_ed25519 (napi_env env, napi_callback_info info) {
-  SN_ARGV(3, crypto_tweak_ed25519)
+napi_value sn_crypto_tweak_ed25519_base (napi_env env, napi_callback_info info) {
+  SN_ARGV(3, crypto_tweak_ed25519_base)
 
   SN_ARGV_TYPEDARRAY(n, 0)
   SN_ARGV_TYPEDARRAY(p, 1)
@@ -2839,7 +2839,7 @@ napi_value sn_crypto_tweak_ed25519 (napi_env env, napi_callback_info info) {
   SN_ASSERT_LENGTH(n_size, crypto_tweak_ed25519_SCALARBYTES, "n")
   SN_ASSERT_LENGTH(p_size, crypto_tweak_ed25519_BYTES, "p")
 
-  crypto_tweak_ed25519(n_data, p_data, ns_data, ns_size);
+  crypto_tweak_ed25519_base(p_data, n_data, ns_data, ns_size);
 
   return NULL;
 }
@@ -2876,23 +2876,23 @@ napi_value sn_crypto_tweak_ed25519_sk_to_scalar (napi_env env, napi_callback_inf
   return NULL;
 }
 
-napi_value sn_crypto_tweak_ed25519_secretkey (napi_env env, napi_callback_info info) {
-  SN_ARGV(3, crypto_tweak_ed25519_secretkey)
+napi_value sn_crypto_tweak_ed25519_scalar (napi_env env, napi_callback_info info) {
+  SN_ARGV(3, crypto_tweak_ed25519_scalar)
 
-  SN_ARGV_TYPEDARRAY(scalar, 0)
-  SN_ARGV_TYPEDARRAY(sk, 1)
+  SN_ARGV_TYPEDARRAY(scalar_out, 0)
+  SN_ARGV_TYPEDARRAY(scalar, 1)
   SN_ARGV_TYPEDARRAY(ns, 2)
 
+  SN_ASSERT_LENGTH(scalar_out_size, crypto_tweak_ed25519_SCALARBYTES, "scalar_out")
   SN_ASSERT_LENGTH(scalar_size, crypto_tweak_ed25519_SCALARBYTES, "scalar")
-  SN_ASSERT_LENGTH(sk_size, crypto_sign_SECRETKEYBYTES, "sk")
 
-  crypto_tweak_ed25519_secretkey(scalar_data, sk_data, ns_data, ns_size);
+  crypto_tweak_ed25519_scalar(scalar_out_data, scalar_data, ns_data, ns_size);
 
   return NULL;
 }
 
-napi_value sn_crypto_tweak_ed25519_publickey (napi_env env, napi_callback_info info) {
-  SN_ARGV(3, crypto_tweak_ed25519_publickey)
+napi_value sn_crypto_tweak_ed25519_pk (napi_env env, napi_callback_info info) {
+  SN_ARGV(3, crypto_tweak_ed25519_pk)
 
   SN_ARGV_TYPEDARRAY(tpk, 0)
   SN_ARGV_TYPEDARRAY(pk, 1)
@@ -2901,7 +2901,7 @@ napi_value sn_crypto_tweak_ed25519_publickey (napi_env env, napi_callback_info i
   SN_ASSERT_LENGTH(tpk_size, crypto_sign_PUBLICKEYBYTES, "tpk")
   SN_ASSERT_LENGTH(pk_size, crypto_sign_PUBLICKEYBYTES, "pk")
 
-  SN_RETURN(crypto_tweak_ed25519_publickey(tpk_data, pk_data, ns_data, ns_size), "failed to tweak public key")
+  SN_RETURN(crypto_tweak_ed25519_pk(tpk_data, pk_data, ns_data, ns_size), "failed to tweak public key")
 }
 
 napi_value sn_crypto_tweak_ed25519_keypair (napi_env env, napi_callback_info info) {
@@ -2937,8 +2937,8 @@ napi_value sn_crypto_tweak_ed25519_scalar_add (napi_env env, napi_callback_info 
   return NULL;
 }
 
-napi_value sn_crypto_tweak_ed25519_publickey_add (napi_env env, napi_callback_info info) {
-  SN_ARGV(3, crypto_tweak_ed25519_publickey)
+napi_value sn_crypto_tweak_ed25519_pk_add (napi_env env, napi_callback_info info) {
+  SN_ARGV(3, crypto_tweak_ed25519_pk)
 
   SN_ARGV_TYPEDARRAY(tpk, 0)
   SN_ARGV_TYPEDARRAY(pk, 1)
@@ -2948,7 +2948,7 @@ napi_value sn_crypto_tweak_ed25519_publickey_add (napi_env env, napi_callback_in
   SN_ASSERT_LENGTH(pk_size, crypto_sign_PUBLICKEYBYTES, "pk")
   SN_ASSERT_LENGTH(p_size, crypto_sign_PUBLICKEYBYTES, "p")
 
-  SN_RETURN(crypto_tweak_ed25519_publickey_add(tpk_data, pk_data, p_data), "failed to add tweak to public key")
+  SN_RETURN(crypto_tweak_ed25519_pk_add(tpk_data, pk_data, p_data), "failed to add tweak to public key")
 }
 
 static napi_value create_sodium_native(napi_env env) {
@@ -3319,14 +3319,14 @@ static napi_value create_sodium_native(napi_env env) {
 
   // crypto_tweak
 
-  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519, sn_crypto_tweak_ed25519)
-  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_keypair, sn_crypto_tweak_ed25519_keypair)
+  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_base, sn_crypto_tweak_ed25519_base)
   SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_sign_detached, sn_crypto_tweak_ed25519_sign_detached)
   SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_sk_to_scalar, sn_crypto_tweak_ed25519_sk_to_scalar)
-  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_secretkey, sn_crypto_tweak_ed25519_secretkey)
-  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_publickey, sn_crypto_tweak_ed25519_publickey)
+  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_scalar, sn_crypto_tweak_ed25519_scalar)
+  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_pk, sn_crypto_tweak_ed25519_pk)
+  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_keypair, sn_crypto_tweak_ed25519_keypair)
   SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_scalar_add, sn_crypto_tweak_ed25519_scalar_add)
-  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_publickey_add, sn_crypto_tweak_ed25519_publickey_add)
+  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_pk_add, sn_crypto_tweak_ed25519_pk_add)
   SN_EXPORT_UINT32(experimental_crypto_tweak_ed25519_BYTES, crypto_tweak_ed25519_BYTES)
   SN_EXPORT_UINT32(experimental_crypto_tweak_ed25519_SCALARBYTES, crypto_tweak_ed25519_SCALARBYTES)
 

--- a/binding.c
+++ b/binding.c
@@ -2951,6 +2951,22 @@ napi_value sn_crypto_tweak_ed25519_pk_add (napi_env env, napi_callback_info info
   SN_RETURN(crypto_tweak_ed25519_pk_add(tpk_data, pk_data, p_data), "failed to add tweak to public key")
 }
 
+napi_value sn_crypto_tweak_ed25519_keypair_add (napi_env env, napi_callback_info info) {
+  SN_ARGV(4, crypto_tweak_ed25519_keypair_add)
+
+  SN_ARGV_TYPEDARRAY(pk, 0)
+  SN_ARGV_TYPEDARRAY(scalar_out, 1)
+  SN_ARGV_TYPEDARRAY(scalar_in, 2)
+  SN_ARGV_TYPEDARRAY(tweak, 3)
+
+  SN_ASSERT_LENGTH(pk_size, crypto_tweak_ed25519_BYTES, "pk")
+  SN_ASSERT_LENGTH(scalar_out_size, crypto_tweak_ed25519_SCALARBYTES, "scalar_out")
+  SN_ASSERT_LENGTH(scalar_in_size, crypto_tweak_ed25519_SCALARBYTES, "scalar_in")
+  SN_ASSERT_LENGTH(tweak_size, crypto_tweak_ed25519_SCALARBYTES, "tweak")
+
+  SN_RETURN(crypto_tweak_ed25519_keypair_add(pk_data, scalar_out_data, scalar_in_data, tweak_data), "failed to add tweak to keypair")
+}
+
 static napi_value create_sodium_native(napi_env env) {
   SN_THROWS(sodium_init() == -1, "sodium_init() failed")
 
@@ -3327,6 +3343,7 @@ static napi_value create_sodium_native(napi_env env) {
   SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_keypair, sn_crypto_tweak_ed25519_keypair)
   SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_scalar_add, sn_crypto_tweak_ed25519_scalar_add)
   SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_pk_add, sn_crypto_tweak_ed25519_pk_add)
+  SN_EXPORT_FUNCTION(experimental_crypto_tweak_ed25519_keypair_add, sn_crypto_tweak_ed25519_keypair_add)
   SN_EXPORT_UINT32(experimental_crypto_tweak_ed25519_BYTES, crypto_tweak_ed25519_BYTES)
   SN_EXPORT_UINT32(experimental_crypto_tweak_ed25519_SCALARBYTES, crypto_tweak_ed25519_SCALARBYTES)
 

--- a/modules/crypto_tweak/tweak.c
+++ b/modules/crypto_tweak/tweak.c
@@ -196,3 +196,11 @@ int crypto_tweak_ed25519_pk_add(unsigned char *tpk,
 {
   return crypto_core_ed25519_add(tpk, pk, q);
 }
+
+
+int crypto_tweak_ed25519_keypair_add(unsigned char *pk, unsigned char *scalar_out,
+                                      unsigned char *scalar, const unsigned char *tweak)
+{
+  crypto_tweak_ed25519_scalar_add(scalar_out, scalar, tweak);
+  return crypto_scalarmult_ed25519_base_noclamp(pk, scalar_out);
+}

--- a/modules/crypto_tweak/tweak.h
+++ b/modules/crypto_tweak/tweak.h
@@ -19,26 +19,26 @@ int crypto_tweak_ed25519_sign_detached(unsigned char *sig, unsigned long long *s
                                        const unsigned char *m, unsigned long long mlen,
                                        const unsigned char *n, unsigned char *pk);
 
-void crypto_tweak_ed25519(unsigned char *n, unsigned char *q,
-                          const unsigned char *ns, unsigned long long nslen);
+void crypto_tweak_ed25519_base(unsigned char *pk, unsigned char *scalar,
+                               const unsigned char *ns, unsigned long long nslen);
+
+void crypto_tweak_ed25519_sk_to_scalar(unsigned char *scalar, const unsigned char *sk);
+
+// tweak a secret key
+void crypto_tweak_ed25519_scalar(unsigned char *scalar_out,
+                                 const unsigned char *scalar,
+                                 const unsigned char *ns,
+                                 unsigned long long nslen);
+
+// tweak a public key
+int crypto_tweak_ed25519_pk(unsigned char *tpk,
+                            const unsigned char *pk,
+                            const unsigned char *ns,
+                            unsigned long long nslen);
 
 void crypto_tweak_ed25519_keypair(unsigned char *pk, unsigned char *scalar_out,
                                   unsigned char *scalar, const unsigned char *ns,
                                   unsigned long long nslen);
-
-void crypto_tweak_ed25519_sk_to_scalar(unsigned char *n, const unsigned char *sk);
-
-// tweak a secret key
-void crypto_tweak_ed25519_secretkey(unsigned char *n,
-                                    const unsigned char *sk,
-                                    const unsigned char *ns,
-                                    unsigned long long nslen);
-
-// tweak a public key
-int crypto_tweak_ed25519_publickey(unsigned char *tpk,
-                                   const unsigned char *pk,
-                                   const unsigned char *ns,
-                                   unsigned long long nslen);
 
 // add tweak scalar to private key
 void crypto_tweak_ed25519_scalar_add(unsigned char *scalar_out,
@@ -46,6 +46,6 @@ void crypto_tweak_ed25519_scalar_add(unsigned char *scalar_out,
                                      const unsigned char *n);
 
 // add tweak point to public key
-int crypto_tweak_ed25519_publickey_add(unsigned char *tpk,
-                                       const unsigned char *pk,
-                                       const unsigned char *q);
+int crypto_tweak_ed25519_pk_add(unsigned char *tpk,
+                                const unsigned char *pk,
+                                const unsigned char *q);

--- a/modules/crypto_tweak/tweak.h
+++ b/modules/crypto_tweak/tweak.h
@@ -49,3 +49,6 @@ void crypto_tweak_ed25519_scalar_add(unsigned char *scalar_out,
 int crypto_tweak_ed25519_pk_add(unsigned char *tpk,
                                 const unsigned char *pk,
                                 const unsigned char *q);
+
+int crypto_tweak_ed25519_keypair_add(unsigned char *pk, unsigned char *scalar_out,
+                                      unsigned char *scalar, const unsigned char *tweak);

--- a/test/crypto_tweak_ed25519.js
+++ b/test/crypto_tweak_ed25519.js
@@ -21,23 +21,24 @@ tape('crypto_tweak', function (t) {
   sodium.crypto_generichash(ns, Buffer.from('namespace'))
 
   t.throws(function () {
-    sodium.experimental_crypto_tweak_ed25519()
+    sodium.experimental_crypto_tweak_ed25519_base()
   }, 'should validate input')
 
   t.throws(function () {
-    sodium.experimental_crypto_tweak_ed25519(Buffer.alloc(0), Buffer.alloc(0), ns)
+    sodium.experimental_crypto_tweak_ed25519_base(Buffer.alloc(0), Buffer.alloc(0), ns)
   }, 'should validate input length')
 
-  sodium.experimental_crypto_tweak_ed25519(tweak, point, ns)
-
-  sodium.experimental_crypto_tweak_ed25519_publickey(tpk, pk, ns)
-  sodium.experimental_crypto_tweak_ed25519_secretkey(tsk, sk, ns)
-
-  sodium.experimental_crypto_tweak_ed25519_publickey_add(pk, pk, point)
+  sodium.experimental_crypto_tweak_ed25519_base(tweak, point, ns)
 
   const _sk = sk.subarray(0, 32)
   sodium.experimental_crypto_tweak_ed25519_sk_to_scalar(_sk, sk)
+
+  sodium.experimental_crypto_tweak_ed25519_pk(tpk, pk, ns)
+  sodium.experimental_crypto_tweak_ed25519_scalar(tsk, _sk, ns)
+
   sodium.experimental_crypto_tweak_ed25519_keypair(tkpk, tksk, _sk, ns)
+
+  sodium.experimental_crypto_tweak_ed25519_pk_add(pk, pk, point)
   sodium.experimental_crypto_tweak_ed25519_scalar_add(_sk, _sk, tweak)
 
   t.deepEquals(pk, tpk, 'tweak public key')
@@ -63,12 +64,13 @@ tape('experimental_crypto_tweak_sign', function (t) {
   const ns = Buffer.alloc(32)
   sodium.crypto_generichash(ns, Buffer.from('namespace'))
 
-  sodium.experimental_crypto_tweak_ed25519(tweak, point, ns)
+  sodium.experimental_crypto_tweak_ed25519_base(tweak, point, ns)
 
-  sodium.experimental_crypto_tweak_ed25519_publickey(tpk, pk, ns)
-  sodium.experimental_crypto_tweak_ed25519_secretkey(tsk, sk, ns)
+  sodium.experimental_crypto_tweak_ed25519_pk(tpk, pk, ns)
+  sodium.experimental_crypto_tweak_ed25519_sk_to_scalar(tsk, sk)
+  sodium.experimental_crypto_tweak_ed25519_scalar(tsk, tsk, ns)
 
-  sodium.experimental_crypto_tweak_ed25519_publickey_add(pk, pk, point)
+  sodium.experimental_crypto_tweak_ed25519_pk_add(pk, pk, point)
 
   const _sk = sk.subarray(0, 32)
   sodium.experimental_crypto_tweak_ed25519_sk_to_scalar(_sk, sk)


### PR DESCRIPTION
Export the following `crypto_tweak` api:

```
// just with namespace
crypto_tweak_ed25519_keypair(pk, scalar, root.scalar, 'namespace')
crypto_tweak_ed25519_pk(pk, pk, 'namespace')

// with precomputed tweak
crypto_tweak_ed25519_base(tweak.publicKey, tweak.scalar, 'namespace')
crypto_tweak_ed25519_sk_to_scalar(scalar, sk)
crypto_tweak_ed25519_pk_add(pk, pk, tweak.publicKey)
crypto_tweak_ed25519_pk_sub(pk, pk, tweak.publicKey)
crypto_tweak_ed25519_scalar_add(scalar, scalar, tweak.scalar)
crypto_tweak_ed25519_keypair_add(pk, scalar, root.scalar, tweak.scalar)
```