### PR TITLE
Avoid circular dependency and disable `HAVE_TI_MODE` on 32-bit architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ target_sources(
     vendor/libsodium/src/libsodium/include/sodium.h
     vendor/libsodium/src/libsodium/include/sodium/private/sse2_64_32.h
     vendor/libsodium/src/libsodium/include/sodium/utils.h
+  PUBLIC
     vendor/libsodium/src/libsodium/include/sodium/version.h
   PRIVATE
     vendor/libsodium/src/libsodium/crypto_aead/aes256gcm/aesni/aead_aes256gcm_aesni.c
@@ -313,7 +314,7 @@ if(target MATCHES "win32")
       HAVE_RAISE=1
       HAVE_SYS_PARAM_H=1
   )
-else()
+elseif(target MATCHES "arm64|x64")
   target_compile_definitions(
     sodium
     PRIVATE

--- a/vendor/libsodium.gyp
+++ b/vendor/libsodium.gyp
@@ -219,10 +219,6 @@
           'HAVE_RAISE=1',
           'HAVE_SYS_PARAM_H=1',
         ],
-      }, {
-        'defines': [
-          'HAVE_TI_MODE=1',
-        ],
       }],
       ['target_arch=="x64"', {
         'defines': [
@@ -236,6 +232,7 @@
         'conditions': [
           ['OS!="win"', {
             'defines': [
+              'HAVE_TI_MODE=1',
               'HAVE_AMD64_ASM=1',
               'HAVE_AVX_ASM=1',
             ],
@@ -251,6 +248,15 @@
             ],
           }],
         ],
+      }],
+      ['target_arch=="arm64"', {
+        'conditions': [
+          ['OS!="win"', {
+            'defines': [
+              'HAVE_TI_MODE=1',
+            ],
+          }],
+        ]
       }],
       ['target_endianness=="le"', {
         'defines': [


### PR DESCRIPTION
This ensures that everything compiles successfully on 32-bit Android.