### PR TITLE
feat: add linux arm64/x64 musl prebuilds

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -84,7 +84,7 @@ jobs:
             exit 1
             ;;
         esac
-        TOOLCHAIN_ARCHIVE_NAME="${{ env.MUSL_HOST_ARCH }}-linux-musl-cross-${TOOLCHAIN_ARCH}-linux"
+        TOOLCHAIN_ARCHIVE_NAME="${TOOLCHAIN_ARCH}-linux-musl-cross-${{ env.MUSL_HOST_ARCH }}-linux"
         wget https://github.com/holepunchto/musl-toolchains/releases/download/${{ env.MUSL_TOOLCHAIN_VERSION }}/${TOOLCHAIN_ARCHIVE_NAME}.zip
         unzip ${TOOLCHAIN_ARCHIVE_NAME}.zip
         echo "$PWD/${TOOLCHAIN_ARCHIVE_NAME}/bin" >> $GITHUB_PATH

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -26,14 +26,16 @@ jobs:
           arch: arm
         - os: ubuntu-22.04
           platform: linux
-          arch: arm64
-          tags: -musl
-          flags: --environment musl
-        - os: ubuntu-22.04
-          platform: linux
           arch: x64
           tags: -musl
           flags: --environment musl
+          musl: x86_64-linux-musl-cross-x86_64-linux
+        - os: ubuntu-22.04
+          platform: linux
+          arch: arm64
+          tags: -musl
+          flags: --environment musl
+          musl: x86_64-linux-musl-cross-aarch64-linux
         - os: macos-14
           platform: darwin
           arch: x64
@@ -61,9 +63,6 @@ jobs:
           arch: arm64
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
-    env:
-      MUSL_TOOLCHAIN_VERSION: v1.2.5
-      MUSL_HOST_ARCH: x86_64
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -72,23 +71,10 @@ jobs:
     - run: choco upgrade llvm
       if: ${{ matrix.platform == 'win32' }}
     - run: |
-        case "${{ matrix.arch }}" in
-          x64)
-            TOOLCHAIN_ARCH="x86_64"
-            ;;
-          arm64)
-            TOOLCHAIN_ARCH="aarch64"
-            ;;
-          *)
-            echo "Error: Unsupported architecture '${{ matrix.arch }}' for musl cross compliation."
-            exit 1
-            ;;
-        esac
-        TOOLCHAIN_ARCHIVE_NAME="${TOOLCHAIN_ARCH}-linux-musl-cross-${{ env.MUSL_HOST_ARCH }}-linux"
-        wget https://github.com/holepunchto/musl-toolchains/releases/download/${{ env.MUSL_TOOLCHAIN_VERSION }}/${TOOLCHAIN_ARCHIVE_NAME}.zip
-        unzip ${TOOLCHAIN_ARCHIVE_NAME}.zip
-        echo "$PWD/${TOOLCHAIN_ARCHIVE_NAME}/bin" >> $GITHUB_PATH
-      if: ${{ matrix.tags == '-musl' && matrix.platform == 'linux'}}
+        gh release download --repo holepunchto/musl-toolchains --pattern ${{ matrix.musl }}.zip v1.2.5
+        unzip ${{ matrix.musl }}.zip -d toolchains/
+        echo "${{ github.workspace }}/toolchains/${{ matrix.musl }}/bin" >> $GITHUB_PATH
+      if: ${{ matrix.platform == 'linux' && matrix.musl }}
     - run: npm install -g bare-make
     - run: npm install
     - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -39,7 +39,7 @@ jobs:
           arch: arm64
           tags: -musl
           flags: --environment musl
-          musl: x86_64-linux-musl-cross-aarch64-linux
+          musl: aarch64-linux-musl-cross-aarch64-linux
         - os: macos-14
           platform: darwin
           arch: x64

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -61,6 +61,9 @@ jobs:
           arch: arm64
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
+    env:
+      MUSL_TOOLCHAIN_VERSION: v1.2.5
+      MUSL_HOST_ARCH: x86_64
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -69,17 +72,23 @@ jobs:
     - run: choco upgrade llvm
       if: ${{ matrix.platform == 'win32' }}
     - run: |
-        wget https://musl.cc/x86_64-linux-musl-cross.tgz
-        tar -xvzf x86_64-linux-musl-cross.tgz
-        ln -s "$PWD/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc" /usr/local/bin/x86_64-linux-musl-cc
-        ln -s "$PWD/x86_64-linux-musl-cross/bin/x86_64-linux-musl-g++" /usr/local/bin/x86_64-linux-musl-c++
-      if: ${{ matrix.tags == '-musl' && matrix.platform == 'linux' && matrix.arch == 'x64' }}
-    - run: |
-        wget https://musl.cc/aarch64-linux-musl-cross.tgz
-        tar -xvzf aarch64-linux-musl-cross.tgz
-        ln -s "$PWD/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc" /usr/local/bin/aarch64-linux-musl-cc
-        ln -s "$PWD/aarch64-linux-musl-cross/bin/aarch64-linux-musl-g++" /usr/local/bin/aarch64-linux-musl-c++
-      if: ${{ matrix.tags == '-musl' && matrix.platform == 'linux' && matrix.arch == 'arm64' }}
+        case "${{ matrix.arch }}" in
+          x64)
+            TOOLCHAIN_ARCH="x86_64"
+            ;;
+          arm64)
+            TOOLCHAIN_ARCH="aarch64"
+            ;;
+          *)
+            echo "Error: Unsupported architecture '${{ matrix.arch }}' for musl cross compliation."
+            exit 1
+            ;;
+        esac
+        TOOLCHAIN_ARCHIVE_NAME="${{ env.MUSL_HOST_ARCH }}-linux-musl-cross-${TOOLCHAIN_ARCH}-linux"
+        wget https://github.com/holepunchto/musl-toolchains/releases/download/${{ env.MUSL_TOOLCHAIN_VERSION }}/${TOOLCHAIN_ARCHIVE_NAME}.zip
+        unzip ${TOOLCHAIN_ARCHIVE_NAME}.zip
+        echo "$PWD/${TOOLCHAIN_ARCHIVE_NAME}/bin" >> $GITHUB_PATH
+      if: ${{ matrix.tags == '-musl' && matrix.platform == 'linux'}}
     - run: npm install -g bare-make
     - run: npm install
     - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -24,6 +24,16 @@ jobs:
         - os: ubuntu-22.04
           platform: android
           arch: arm
+        - os: ubuntu-22.04
+          platform: linux
+          arch: arm64
+          tags: -musl
+          flags: --environment musl
+        - os: ubuntu-22.04
+          platform: linux
+          arch: x64
+          tags: -musl
+          flags: --environment musl
         - os: macos-14
           platform: darwin
           arch: x64
@@ -58,6 +68,18 @@ jobs:
         node-version: lts/*
     - run: choco upgrade llvm
       if: ${{ matrix.platform == 'win32' }}
+    - run: |
+        wget https://musl.cc/x86_64-linux-musl-cross.tgz
+        tar -xvzf x86_64-linux-musl-cross.tgz
+        ln -s "$PWD/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc" /usr/local/bin/x86_64-linux-musl-cc
+        ln -s "$PWD/x86_64-linux-musl-cross/bin/x86_64-linux-musl-g++" /usr/local/bin/x86_64-linux-musl-c++
+      if: ${{ matrix.tags == '-musl' && matrix.platform == 'linux' && matrix.arch == 'x64' }}
+    - run: |
+        wget https://musl.cc/aarch64-linux-musl-cross.tgz
+        tar -xvzf aarch64-linux-musl-cross.tgz
+        ln -s "$PWD/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc" /usr/local/bin/aarch64-linux-musl-cc
+        ln -s "$PWD/aarch64-linux-musl-cross/bin/aarch64-linux-musl-g++" /usr/local/bin/aarch64-linux-musl-c++
+      if: ${{ matrix.tags == '-musl' && matrix.platform == 'linux' && matrix.arch == 'arm64' }}
     - run: npm install -g bare-make
     - run: npm install
     - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}


### PR DESCRIPTION
This adds musl prebuilds for linux arm64/x64. This helps to make it work out of the box on alpine which otherwise is quite a hassle to install a musl environment and prebuild by yourself (also adds another minute on the build process).