### PR TITLE
Handle `libsodium` already having been initialized

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -3677,7 +3677,7 @@ sodium_native_exports(js_env_t *env, js_value_t *exports) {
   int err;
 
   err = sodium_init();
-  assert(err == 0 && "sodium init");
+  assert(err >= 0);
 
 #define V_FUNCTION(name, fn) \
   err = js_set_property<fn>(env, exports, name); \


### PR DESCRIPTION
The assertion otherwise fails when loading `sodium-native` from multiple threads.