### PR TITLE
fix(onetimeauth): prevent double final

### DIFF
--- a/index.js
+++ b/index.js
@@ -1317,6 +1317,8 @@ exports.crypto_onetimeauth = function (out, input, k) {
   if (res !== 0) throw new Error('status: ' + res)
 }
 
+const _onetimeauthFinalized = new WeakSet()
+
 exports.crypto_onetimeauth_init = function (state, k) {
   assert(ArrayBuffer.isView(state), 'state must be a typed array')
   assert(ArrayBuffer.isView(k), 'k must be a typed array')
@@ -1328,6 +1330,8 @@ exports.crypto_onetimeauth_init = function (state, k) {
     k.byteLength === binding.crypto_onetimeauth_KEYBYTES,
     "k must be 'crypto_onetimeauth_KEYBYTES' bytes"
   )
+
+  _onetimeauthFinalized.delete(state.buffer)
 
   const res = binding.crypto_onetimeauth_init(state, k)
 
@@ -1341,6 +1345,7 @@ exports.crypto_onetimeauth_update = function (state, input) {
     state.byteLength === binding.crypto_onetimeauth_STATEBYTES,
     "state must be 'crypto_onetimeauth_STATEBYTES' bytes"
   )
+  assert(!_onetimeauthFinalized.has(state.buffer), 'state has already been finalized')
 
   const res = binding.crypto_onetimeauth_update(state, input)
 
@@ -1358,8 +1363,11 @@ exports.crypto_onetimeauth_final = function (state, out) {
     out.byteLength === binding.crypto_onetimeauth_BYTES,
     "out must be 'crypto_onetimeauth_BYTES' bytes"
   )
+  assert(!_onetimeauthFinalized.has(state.buffer), 'state has already been finalized')
 
   const res = binding.crypto_onetimeauth_final(state, out)
+
+  _onetimeauthFinalized.add(state.buffer)
 
   if (res !== 0) throw new Error('status: ' + res)
 }

--- a/index.js
+++ b/index.js
@@ -1337,6 +1337,7 @@ exports.crypto_onetimeauth_init = function (state, k) {
 exports.crypto_onetimeauth_update = function (state, input) {
   assert(ArrayBuffer.isView(state), 'state must be a typed array')
   assert(ArrayBuffer.isView(input), 'input must be a typed array')
+  assert(!state.buffer.detached, 'state has already been finalized')
   assert(
     state.byteLength === binding.crypto_onetimeauth_STATEBYTES,
     "state must be 'crypto_onetimeauth_STATEBYTES' bytes"

--- a/index.js
+++ b/index.js
@@ -1317,8 +1317,6 @@ exports.crypto_onetimeauth = function (out, input, k) {
   if (res !== 0) throw new Error('status: ' + res)
 }
 
-const _onetimeauthFinalized = new WeakSet()
-
 exports.crypto_onetimeauth_init = function (state, k) {
   assert(ArrayBuffer.isView(state), 'state must be a typed array')
   assert(ArrayBuffer.isView(k), 'k must be a typed array')
@@ -1330,8 +1328,6 @@ exports.crypto_onetimeauth_init = function (state, k) {
     k.byteLength === binding.crypto_onetimeauth_KEYBYTES,
     "k must be 'crypto_onetimeauth_KEYBYTES' bytes"
   )
-
-  _onetimeauthFinalized.delete(state.buffer)
 
   const res = binding.crypto_onetimeauth_init(state, k)
 
@@ -1345,7 +1341,6 @@ exports.crypto_onetimeauth_update = function (state, input) {
     state.byteLength === binding.crypto_onetimeauth_STATEBYTES,
     "state must be 'crypto_onetimeauth_STATEBYTES' bytes"
   )
-  assert(!_onetimeauthFinalized.has(state.buffer), 'state has already been finalized')
 
   const res = binding.crypto_onetimeauth_update(state, input)
 
@@ -1355,6 +1350,7 @@ exports.crypto_onetimeauth_update = function (state, input) {
 exports.crypto_onetimeauth_final = function (state, out) {
   assert(ArrayBuffer.isView(state), 'state must be a typed array')
   assert(ArrayBuffer.isView(out), 'out must be a typed array')
+  assert(!state.buffer.detached, 'state has already been finalized')
   assert(
     state.byteLength === binding.crypto_onetimeauth_STATEBYTES,
     "state must be 'crypto_onetimeauth_STATEBYTES' bytes"
@@ -1363,11 +1359,10 @@ exports.crypto_onetimeauth_final = function (state, out) {
     out.byteLength === binding.crypto_onetimeauth_BYTES,
     "out must be 'crypto_onetimeauth_BYTES' bytes"
   )
-  assert(!_onetimeauthFinalized.has(state.buffer), 'state has already been finalized')
 
   const res = binding.crypto_onetimeauth_final(state, out)
 
-  _onetimeauthFinalized.add(state.buffer)
+  state.buffer.transfer()
 
   if (res !== 0) throw new Error('status: ' + res)
 }

--- a/test/crypto_onetimeauth.js
+++ b/test/crypto_onetimeauth.js
@@ -17,6 +17,26 @@ test('crypto_onetimeauth', function (t) {
   t.ok(sodium.crypto_onetimeauth_verify(mac, value, key), 'verifies')
 })
 
+test('crypto_onetimeauth - double final must not produce zero MAC', function (t) {
+  const key = Buffer.alloc(sodium.crypto_onetimeauth_KEYBYTES)
+  const state = Buffer.alloc(sodium.crypto_onetimeauth_STATEBYTES)
+  const out = Buffer.alloc(sodium.crypto_onetimeauth_BYTES)
+
+  sodium.randombytes_buf(key)
+  sodium.crypto_onetimeauth_init(state, key)
+  sodium.crypto_onetimeauth_update(state, Buffer.from('hello'))
+  sodium.crypto_onetimeauth_final(state, out)
+
+  const validMac = Buffer.from(out)
+  t.not(validMac, Buffer.alloc(validMac.length), 'first final produces valid MAC')
+
+  t.exception.all(function () {
+    sodium.crypto_onetimeauth_final(state, out)
+  }, 'second final throws instead of producing zero MAC')
+
+  t.alike(out, validMac, 'MAC was not overwritten by second final')
+})
+
 test('crypto_onetimeauth_state', function (t) {
   const key = Buffer.alloc(sodium.crypto_onetimeauth_KEYBYTES, 'lo')
   const state = Buffer.alloc(sodium.crypto_onetimeauth_STATEBYTES)

--- a/test/crypto_onetimeauth.js
+++ b/test/crypto_onetimeauth.js
@@ -37,6 +37,21 @@ test('crypto_onetimeauth - double final must not produce zero MAC', function (t)
   t.alike(out, validMac, 'MAC was not overwritten by second final')
 })
 
+test('crypto_onetimeauth - update after final must throw', function (t) {
+  const key = Buffer.alloc(sodium.crypto_onetimeauth_KEYBYTES)
+  const state = Buffer.alloc(sodium.crypto_onetimeauth_STATEBYTES)
+  const out = Buffer.alloc(sodium.crypto_onetimeauth_BYTES)
+
+  sodium.randombytes_buf(key)
+  sodium.crypto_onetimeauth_init(state, key)
+  sodium.crypto_onetimeauth_update(state, Buffer.from('hello'))
+  sodium.crypto_onetimeauth_final(state, out)
+
+  t.exception.all(function () {
+    sodium.crypto_onetimeauth_update(state, Buffer.from('world'))
+  }, 'update after final throws')
+})
+
 test('crypto_onetimeauth_state', function (t) {
   const key = Buffer.alloc(sodium.crypto_onetimeauth_KEYBYTES, 'lo')
   const state = Buffer.alloc(sodium.crypto_onetimeauth_STATEBYTES)


### PR DESCRIPTION
 ```js
  const sodium = require('sodium-native')                                                                   
                                                                                                            
  const state = Buffer.alloc(sodium.crypto_onetimeauth_STATEBYTES)                                          
  const key = Buffer.alloc(sodium.crypto_onetimeauth_KEYBYTES)                                            
  const out = Buffer.alloc(sodium.crypto_onetimeauth_BYTES)                                                 
                                                                                                            
  sodium.randombytes_buf(key)
  sodium.crypto_onetimeauth_init(state, key)
  sodium.crypto_onetimeauth_update(state, Buffer.from('hello'))

  sodium.crypto_onetimeauth_final(state, out)
  console.log('1st final (valid MAC):', out.toString('hex'))

  sodium.crypto_onetimeauth_final(state, out)
  console.log('2nd final (zero MAC) :', out.toString('hex'))
```

Output:

```console
  # Before
  1st final (valid MAC): bade9f242a8dce16b18e8f4ef409b0fb
  2nd final (zero MAC) : 00000000000000000000000000000000

  # After
  1st final (valid MAC): bade9f242a8dce16b18e8f4ef409b0fb
  AssertionError: state has already been finalized
```